### PR TITLE
Backend allapi

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -87,7 +87,7 @@ func routeRestAPI(router *gin.Engine) {
 
 		issue.POST("/:issue_id/cherrypick/:version_name", controller.CreateOrUpdateVersionTriage)
 		issue.PATCH("/:issue_id/cherrypick/:version_name", controller.CreateOrUpdateVersionTriage)
-		issue.GET("/cherrypick/:version", controller.SelectVersionTriageInfos)
+		issue.GET("/cherrypick/:version", controller.SelectVersionTriageInfo)
 		issue.GET("/cherrypick/result", controller.SelectVersionTriageResult)
 
 		issue.PATCH("/:issue_id/affect/:version_name", controller.CreateOrUpdateIssueAffect)

--- a/internal/controller/version_triage_info.go
+++ b/internal/controller/version_triage_info.go
@@ -34,7 +34,7 @@ func CreateOrUpdateVersionTriage(c *gin.Context) {
 	c.JSON(statusCode, gin.H{"status": "ok", "data": versionTriageInfo})
 }
 
-func SelectVersionTriageInfos(c *gin.Context) {
+func SelectVersionTriageInfo(c *gin.Context) {
 	// Params
 	versionTriageInfoQuery := dto.VersionTriageInfoQuery{}
 	if err := c.ShouldBindUri(&versionTriageInfoQuery); err != nil {

--- a/internal/entity/issue_pr_relation.go
+++ b/internal/entity/issue_pr_relation.go
@@ -19,6 +19,10 @@ type IssuePrRelationOption struct {
 	ID            int64  `json:"id" form:"id"`
 	IssueID       string `json:"issue_id,omitempty" form:"issue_id"`
 	PullRequestID string `json:"pull_request_id,omitempty" form:"pull_request_id"`
+
+	IssueIDs []string `json:"issue_ids,omitempty" form:"issue_ids"`
+
+	ListOption
 }
 
 // DB-Table

--- a/internal/entity/release_version.go
+++ b/internal/entity/release_version.go
@@ -75,6 +75,10 @@ type ReleaseVersionOption struct {
 	Addition string               `json:"addition,omitempty"`
 	Type     ReleaseVersionType   `json:"type,omitempty" form:"type"`
 	Status   ReleaseVersionStatus `json:"status,omitempty" form:"status"`
+
+	StatusList []ReleaseVersionStatus `json:"status_list,omitempty" form:"status_list"`
+
+	ListOption
 }
 
 // DB-Table

--- a/internal/entity/version_triage.go
+++ b/internal/entity/version_triage.go
@@ -57,6 +57,7 @@ type VersionTriageOption struct {
 	IssueID      string              `json:"issue_id,omitempty" form:"issue_id" uri:"issue_id"`
 	TriageResult VersionTriageResult `json:"triage_result,omitempty" form:"triage_result" uri:"triage_result"`
 
+	IssueIDs        []string `json:"issue_ids,omitempty" form:"issue_ids" uri:"issue_ids"`
 	VersionNameList []string `json:"version_name_list,omitempty" form:"version_name_list" uri:"version_name_list"`
 
 	ListOption

--- a/internal/entity/version_triage.go
+++ b/internal/entity/version_triage.go
@@ -57,6 +57,8 @@ type VersionTriageOption struct {
 	IssueID      string              `json:"issue_id,omitempty" form:"issue_id" uri:"issue_id"`
 	TriageResult VersionTriageResult `json:"triage_result,omitempty" form:"triage_result" uri:"triage_result"`
 
+	VersionNameList []string `json:"version_name_list,omitempty" form:"version_name_list" uri:"version_name_list"`
+
 	ListOption
 }
 

--- a/internal/repository/release_version.go
+++ b/internal/repository/release_version.go
@@ -33,6 +33,10 @@ func UpdateReleaseVersion(version *entity.ReleaseVersion) error {
 	if version.UpdateTime.IsZero() {
 		version.UpdateTime = time.Now()
 	}
+	if version.Status == entity.ReleaseVersionStatusReleased {
+		releaseTime := time.Now()
+		version.ActualReleaseTime = &releaseTime
+	}
 	serializeReleaseVersion(version)
 
 	// 更新

--- a/internal/repository/release_version.go
+++ b/internal/repository/release_version.go
@@ -11,6 +11,21 @@ import (
 	"github.com/pkg/errors"
 )
 
+func SelectReleaseVersion(option *entity.ReleaseVersionOption) (*[]entity.ReleaseVersion, error) {
+	sql := "select * from release_version where 1=1" + ReleaseVersionWhere(option) + ReleaseVersionOrderBy(option) + ReleaseVersionLimit(option)
+	// 查询
+	var releaseVersions []entity.ReleaseVersion
+	if err := database.DBConn.RawWrapper(sql, option).Find(&releaseVersions).Error; err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("find release version: %+v failed", option))
+	}
+
+	// 加工
+	for i := 0; i < len(releaseVersions); i++ {
+		unSerializeReleaseVersion(&releaseVersions[i])
+	}
+	return &releaseVersions, nil
+}
+
 func CreateReleaseVersion(version *entity.ReleaseVersion) error {
 	// 加工
 	if version.CreateTime.IsZero() {
@@ -44,20 +59,6 @@ func UpdateReleaseVersion(version *entity.ReleaseVersion) error {
 		return errors.Wrap(err, fmt.Sprintf("update release version: %+v failed", version))
 	}
 	return nil
-}
-
-func SelectReleaseVersion(option *entity.ReleaseVersionOption) (*[]entity.ReleaseVersion, error) {
-	// 查询
-	var releaseVersions []entity.ReleaseVersion
-	if err := database.DBConn.DB.Where(option).Order("major desc, minor desc, patch desc, create_time desc").Find(&releaseVersions).Error; err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("find release version: %+v failed", option))
-	}
-
-	// 加工
-	for i := 0; i < len(releaseVersions); i++ {
-		unSerializeReleaseVersion(&releaseVersions[i])
-	}
-	return &releaseVersions, nil
 }
 
 func SelectReleaseVersionLatest(option *entity.ReleaseVersionOption) (*entity.ReleaseVersion, error) {
@@ -98,4 +99,64 @@ func unSerializeReleaseVersion(version *entity.ReleaseVersion) {
 		json.Unmarshal([]byte(version.LabelsString), &labels)
 		version.Labels = &labels
 	}
+}
+
+func ReleaseVersionWhere(option *entity.ReleaseVersionOption) string {
+	sql := ""
+
+	if option.ID != 0 {
+		sql += " and release_version.id = @ID"
+	}
+	if option.Name != "" {
+		sql += " and release_version.name = @Name"
+	}
+	if option.Major != 0 {
+		sql += " and release_version.major = @Major"
+	}
+	if option.Minor != 0 {
+		sql += " and release_version.minor = @Minor"
+	}
+	if option.Patch != 0 {
+		sql += " and release_version.patch = @Patch"
+	}
+	if option.Addition != "" {
+		sql += " and release_version.addition = @Addition"
+	}
+	if option.Type != "" {
+		sql += " and release_version.type = @Type"
+	}
+	if option.Status != "" {
+		sql += " and release_version.status = @Status"
+	}
+	if option.StatusList != nil && len(option.StatusList) > 0 {
+		sql += " and release_version.status in @StatusList"
+	}
+	return sql
+}
+
+func ReleaseVersionOrderBy(option *entity.ReleaseVersionOption) string {
+	sql := ""
+
+	if option.OrderBy != "" {
+		sql += " order by " + option.OrderBy
+	}
+	if option.Order != "" {
+		sql += " " + option.Order
+	}
+	if option.OrderBy == "" && option.Order == "" {
+		sql += " order by major desc, minor desc, patch desc, create_time desc"
+	}
+
+	return sql
+}
+
+func ReleaseVersionLimit(option *entity.ReleaseVersionOption) string {
+	sql := ""
+
+	if option.Page != 0 && option.PerPage != 0 {
+		option.ListOption.CalcOffset()
+		sql += " limit @Offset,@PerPage"
+	}
+
+	return sql
 }

--- a/internal/repository/version_triage.go
+++ b/internal/repository/version_triage.go
@@ -92,6 +92,9 @@ func VersionTriageWhere(option *entity.VersionTriageOption) string {
 	if option.TriageResult != "" {
 		sql += " and version_triage.triage_result = @TriageResult"
 	}
+	if option.VersionNameList != nil && len(option.VersionNameList) > 0 {
+		sql += " and version_triage.version_name in @VersionNameList"
+	}
 
 	return sql
 }

--- a/internal/repository/version_triage.go
+++ b/internal/repository/version_triage.go
@@ -92,6 +92,9 @@ func VersionTriageWhere(option *entity.VersionTriageOption) string {
 	if option.TriageResult != "" {
 		sql += " and version_triage.triage_result = @TriageResult"
 	}
+	if option.IssueIDs != nil && len(option.IssueIDs) > 0 {
+		sql += " and version_triage.issue_id in @IssueIDs"
+	}
 	if option.VersionNameList != nil && len(option.VersionNameList) > 0 {
 		sql += " and version_triage.version_name in @VersionNameList"
 	}

--- a/internal/service/issue_affect.go
+++ b/internal/service/issue_affect.go
@@ -73,16 +73,6 @@ func OperateIssueAffectResult(issueAffect *entity.IssueAffect) error {
 	// operate cherry-pick record: select latest version & insert cherry-pick
 	if issueAffect.AffectResult == entity.AffectResultResultYes {
 		major, minor, _, _ := ComposeVersionAtom(issueAffect.AffectVersion)
-		// releaseVersionOption := &entity.ReleaseVersionOption{
-		// 	Major:  major,
-		// 	Minor:  minor,
-		// 	Status: entity.ReleaseVersionStatusUpcoming,
-		// 	// Type:                     entity.ReleaseVersionTypePatch,
-		// }
-		// releaseVersion, err := repository.SelectReleaseVersionLatest(releaseVersionOption)
-		// if err != nil {
-		// 	return err
-		// }
 		versionTriage := &entity.VersionTriage{
 			IssueID:      issueAffect.IssueID,
 			VersionName:  ComposeVersionMinorName(&entity.ReleaseVersion{Major: major, Minor: minor}),

--- a/internal/service/issue_affect.go
+++ b/internal/service/issue_affect.go
@@ -71,18 +71,18 @@ func OperateIssueAffectResult(issueAffect *entity.IssueAffect) error {
 	}
 
 	// operate cherry-pick record: select latest version & insert cherry-pick
-	if issueAffect.AffectResult == entity.AffectResultResultYes {
-		major, minor, _, _ := ComposeVersionAtom(issueAffect.AffectVersion)
-		versionTriage := &entity.VersionTriage{
-			IssueID:      issueAffect.IssueID,
-			VersionName:  ComposeVersionMinorName(&entity.ReleaseVersion{Major: major, Minor: minor}),
-			TriageResult: entity.VersionTriageResultUnKnown,
-		}
-		_, err := CreateOrUpdateVersionTriageInfo(versionTriage)
-		if err != nil {
-			return err
-		}
-	}
+	// if issueAffect.AffectResult == entity.AffectResultResultYes {
+	// 	major, minor, _, _ := ComposeVersionAtom(issueAffect.AffectVersion)
+	// 	versionTriage := &entity.VersionTriage{
+	// 		IssueID:      issueAffect.IssueID,
+	// 		VersionName:  ComposeVersionMinorName(&entity.ReleaseVersion{Major: major, Minor: minor}),
+	// 		TriageResult: entity.VersionTriageResultUnKnown,
+	// 	}
+	// 	_, err := CreateOrUpdateVersionTriageInfo(versionTriage)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	return nil
 }

--- a/internal/service/issue_relation_info_local.go
+++ b/internal/service/issue_relation_info_local.go
@@ -94,7 +94,7 @@ func SelectIssueRelationInfo(option *dto.IssueRelationInfoQuery) (*[]dto.IssueRe
 		pullRequestOption := &entity.PullRequestOption{
 			PullRequestIDs: pullRequestIDs,
 		}
-		if pullRequestOption.BaseBranch != "" {
+		if option.BaseBranch != "" {
 			pullRequestOption.BaseBranch = option.BaseBranch
 		}
 		pullRequestAlls, err := repository.SelectPullRequest(pullRequestOption)

--- a/internal/service/issue_relation_info_local.go
+++ b/internal/service/issue_relation_info_local.go
@@ -32,83 +32,220 @@ func SelectIssueRelationInfo(option *dto.IssueRelationInfoQuery) (*[]dto.IssueRe
 	}
 	response.CalcTotalPage()
 
+	// batch select all issue relation info
+	issueIDs := make([]string, 0)
+	issueAffectIDs := make([]int64, 0)
+	pullRequestIDs := make([]string, 0)
+	for i := range *joins {
+		join := (*joins)[i]
+		issueIDs = append(issueIDs, join.IssueID)
+
+		ids := strings.Split(join.IssueAffectIDs, ",")
+		for _, id := range ids {
+			idint, _ := strconv.Atoi(id)
+			issueAffectIDs = append(issueAffectIDs, int64(idint))
+		}
+	}
+
+	issueAll := make([]entity.Issue, 0)
+	issueAffectAll := make([]entity.IssueAffect, 0)
+	issuePrRelationAll := make([]entity.IssuePrRelation, 0)
+	pullRequestAll := make([]entity.PullRequest, 0)
+	versionTriageAll := make([]entity.VersionTriage, 0)
+
+	if len(issueIDs) > 0 {
+		issueOption := &entity.IssueOption{
+			IssueIDs: issueIDs,
+		}
+		issueAlls, err := repository.SelectIssue(issueOption)
+		if nil != err {
+			return nil, nil, err
+		}
+		issueAll = append(issueAll, (*issueAlls)...)
+	}
+
+	if len(issueAffectIDs) > 0 {
+		issueAffectOption := &entity.IssueAffectOption{
+			IDs: issueAffectIDs,
+		}
+		issueAffectAlls, err := repository.SelectIssueAffect(issueAffectOption)
+		if nil != err {
+			return nil, nil, err
+		}
+		issueAffectAll = append(issueAffectAll, (*issueAffectAlls)...)
+	}
+
+	if len(issueIDs) > 0 {
+		issuePrRelation := &entity.IssuePrRelationOption{
+			IssueIDs: issueIDs,
+		}
+		issuePrRelationAlls, err := repository.SelectIssuePrRelation(issuePrRelation)
+		if nil != err {
+			return nil, nil, err
+		}
+		issuePrRelationAll = append(issuePrRelationAll, (*issuePrRelationAlls)...)
+	}
+
+	if len(issuePrRelationAll) > 0 {
+		for i := range issuePrRelationAll {
+			issuePrRelation := issuePrRelationAll[i]
+			pullRequestIDs = append(pullRequestIDs, issuePrRelation.PullRequestID)
+		}
+		pullRequestOption := &entity.PullRequestOption{
+			PullRequestIDs: pullRequestIDs,
+		}
+		if pullRequestOption.BaseBranch != "" {
+			pullRequestOption.BaseBranch = option.BaseBranch
+		}
+		pullRequestAlls, err := repository.SelectPullRequest(pullRequestOption)
+		if nil != err {
+			return nil, nil, err
+		}
+		pullRequestAll = append(pullRequestAll, (*pullRequestAlls)...)
+	}
+
+	if len(issueIDs) > 0 {
+		versionTriageOption := &entity.VersionTriageOption{
+			IssueIDs: issueIDs,
+		}
+		versionTriageAlls, err := repository.SelectVersionTriage(versionTriageOption)
+		if nil != err {
+			return nil, nil, err
+		}
+		versionTriageAll = append(versionTriageAll, (*versionTriageAlls)...)
+	}
+
 	// compose
 	issueRelationInfos := make([]dto.IssueRelationInfo, 0)
-	for _, join := range *joins {
+	for index := range issueAll {
+		issue := issueAll[index]
+
 		issueRelationInfo := &dto.IssueRelationInfo{}
+		issueRelationInfo.Issue = &issue
 
-		// issue
-		issueOption := &entity.IssueOption{
-			IssueID: join.IssueID,
-		}
-		issue, err := repository.SelectIssueUnique(issueOption)
-		if nil != err {
-			return nil, nil, err
-		}
-		issueRelationInfo.Issue = issue
-
-		// issue_affects
-		if join.IssueAffectIDs != "" {
-			idList := make([]int64, 0)
-			ids := strings.Split(join.IssueAffectIDs, ",")
-			for _, id := range ids {
-				idint, _ := strconv.Atoi(id)
-				idList = append(idList, int64(idint))
+		issueAffects := make([]entity.IssueAffect, 0)
+		if len(issueAffectAll) > 0 {
+			for i := range issueAffectAll {
+				issueAffect := issueAffectAll[i]
+				if issueAffect.IssueID == issue.IssueID {
+					issueAffects = append(issueAffects, issueAffect)
+				}
 			}
-
-			issueAffectOption := &entity.IssueAffectOption{
-				IDs: idList,
-			}
-			issueAffects, err := repository.SelectIssueAffect(issueAffectOption)
-			if nil != err {
-				return nil, nil, err
-			}
-			issueRelationInfo.IssueAffects = issueAffects
 		}
+		issueRelationInfo.IssueAffects = &issueAffects
 
-		// issue_pr_relations
-		issuePrRelationOption := &entity.IssuePrRelationOption{
-			IssueID: issue.IssueID,
-		}
-		issuePrRelations, err := repository.SelectIssuePrRelation(issuePrRelationOption)
-		if nil != err {
-			return nil, nil, err
-		}
-		issueRelationInfo.IssuePrRelations = issuePrRelations
+		issuePrRelations := make([]entity.IssuePrRelation, 0)
+		pullRequests := make([]entity.PullRequest, 0)
+		if len(issuePrRelationAll) > 0 {
+			for i := range issuePrRelationAll {
+				issuePrRelation := issuePrRelationAll[i]
+				if issuePrRelation.IssueID != issue.IssueID {
+					continue
+				}
 
-		// prs
-		if issuePrRelations != nil && len(*issuePrRelations) > 0 {
-			pullRequestIDs := make([]string, 0)
-			for _, issuePrRelation := range *issuePrRelations {
-				pullRequestIDs = append(pullRequestIDs, string(issuePrRelation.PullRequestID))
+				issuePrRelations = append(issuePrRelations, issuePrRelation)
+				if len(pullRequestAll) > 0 {
+					for j := range pullRequestAll {
+						pullRequest := pullRequestAll[j]
+						if pullRequest.PullRequestID == issuePrRelation.PullRequestID {
+							pullRequests = append(pullRequests, pullRequest)
+						}
+					}
+				}
 			}
-
-			pullRequestOption := &entity.PullRequestOption{
-				PullRequestIDs: pullRequestIDs,
-			}
-			if option.BaseBranch != "" {
-				pullRequestOption.BaseBranch = option.BaseBranch
-			}
-			pullRequests, err := repository.SelectPullRequest(pullRequestOption)
-			if nil != err {
-				return nil, nil, err
-			}
-			issueRelationInfo.PullRequests = pullRequests
 		}
+		issueRelationInfo.IssuePrRelations = &issuePrRelations
+		issueRelationInfo.PullRequests = &pullRequests
 
-		// version_triage
-		versionTriageOption := &entity.VersionTriageOption{
-			IssueID: issue.IssueID,
+		versionTriages := make([]entity.VersionTriage, 0)
+		if len(versionTriageAll) > 0 {
+			for i := range versionTriageAll {
+				versionTriage := versionTriageAll[i]
+				if versionTriage.IssueID == issue.IssueID {
+					versionTriages = append(versionTriages, versionTriage)
+				}
+			}
 		}
-		versionTriages, err := repository.SelectVersionTriage(versionTriageOption)
-		if nil != err {
-			return nil, nil, err
-		}
-		issueRelationInfo.VersionTriages = versionTriages
+		issueRelationInfo.VersionTriages = &versionTriages
 
-		// return
 		issueRelationInfos = append(issueRelationInfos, *issueRelationInfo)
 	}
+
+	// for _, join := range *joins {
+	// 	issueRelationInfo := &dto.IssueRelationInfo{}
+
+	// 	// issue
+	// 	issueOption := &entity.IssueOption{
+	// 		IssueID: join.IssueID,
+	// 	}
+	// 	issue, err := repository.SelectIssueUnique(issueOption)
+	// 	if nil != err {
+	// 		return nil, nil, err
+	// 	}
+	// 	issueRelationInfo.Issue = issue
+
+	// 	// issue_affects
+	// 	if join.IssueAffectIDs != "" {
+	// 		idList := make([]int64, 0)
+	// 		ids := strings.Split(join.IssueAffectIDs, ",")
+	// 		for _, id := range ids {
+	// 			idint, _ := strconv.Atoi(id)
+	// 			idList = append(idList, int64(idint))
+	// 		}
+
+	// 		issueAffectOption := &entity.IssueAffectOption{
+	// 			IDs: idList,
+	// 		}
+	// 		issueAffects, err := repository.SelectIssueAffect(issueAffectOption)
+	// 		if nil != err {
+	// 			return nil, nil, err
+	// 		}
+	// 		issueRelationInfo.IssueAffects = issueAffects
+	// 	}
+
+	// 	// issue_pr_relations
+	// 	issuePrRelationOption := &entity.IssuePrRelationOption{
+	// 		IssueID: issue.IssueID,
+	// 	}
+	// 	issuePrRelations, err := repository.SelectIssuePrRelation(issuePrRelationOption)
+	// 	if nil != err {
+	// 		return nil, nil, err
+	// 	}
+	// 	issueRelationInfo.IssuePrRelations = issuePrRelations
+
+	// 	// prs
+	// 	if issuePrRelations != nil && len(*issuePrRelations) > 0 {
+	// 		pullRequestIDs := make([]string, 0)
+	// 		for _, issuePrRelation := range *issuePrRelations {
+	// 			pullRequestIDs = append(pullRequestIDs, string(issuePrRelation.PullRequestID))
+	// 		}
+
+	// 		pullRequestOption := &entity.PullRequestOption{
+	// 			PullRequestIDs: pullRequestIDs,
+	// 		}
+	// 		if option.BaseBranch != "" {
+	// 			pullRequestOption.BaseBranch = option.BaseBranch
+	// 		}
+	// 		pullRequests, err := repository.SelectPullRequest(pullRequestOption)
+	// 		if nil != err {
+	// 			return nil, nil, err
+	// 		}
+	// 		issueRelationInfo.PullRequests = pullRequests
+	// 	}
+
+	// 	// version_triage
+	// 	versionTriageOption := &entity.VersionTriageOption{
+	// 		IssueID: issue.IssueID,
+	// 	}
+	// 	versionTriages, err := repository.SelectVersionTriage(versionTriageOption)
+	// 	if nil != err {
+	// 		return nil, nil, err
+	// 	}
+	// 	issueRelationInfo.VersionTriages = versionTriages
+
+	// 	// return
+	// 	issueRelationInfos = append(issueRelationInfos, *issueRelationInfo)
+	// }
 
 	return &issueRelationInfos, response, nil
 }

--- a/internal/service/release_version.go
+++ b/internal/service/release_version.go
@@ -150,7 +150,11 @@ func ComposeVersionName(version *entity.ReleaseVersion) string {
 }
 
 func ComposeVersionMinorName(version *entity.ReleaseVersion) string {
-	return fmt.Sprintf("%d.%d", version.Major, version.Minor)
+	return ComposeVersionMinorNameByNumber(version.Major, version.Minor)
+}
+
+func ComposeVersionMinorNameByNumber(major, minor int) string {
+	return fmt.Sprintf("%d.%d", major, minor)
 }
 
 func ComposeVersionBranch(version *entity.ReleaseVersion) string {

--- a/internal/service/release_version.go
+++ b/internal/service/release_version.go
@@ -88,10 +88,12 @@ func SelectReleaseVersionMaintained() (*[]string, error) {
 }
 
 func CreateNextVersionIfNotExist(preVersion *entity.ReleaseVersion) (*entity.ReleaseVersion, error) {
+	major, minor, patch, _ := ComposeVersionAtom(preVersion.Name)
+
 	option := &entity.ReleaseVersionOption{
-		Major: preVersion.Major,
-		Minor: preVersion.Minor,
-		Patch: preVersion.Patch + 1,
+		Major: major,
+		Minor: minor,
+		Patch: patch + 1,
 	}
 	version, err := repository.SelectReleaseVersionLatest(option)
 	if nil == err && nil != version {
@@ -99,9 +101,9 @@ func CreateNextVersionIfNotExist(preVersion *entity.ReleaseVersion) (*entity.Rel
 	}
 	if nil == version {
 		version = &entity.ReleaseVersion{
-			Major: preVersion.Major,
-			Minor: preVersion.Minor,
-			Patch: preVersion.Patch + 1,
+			Major: major,
+			Minor: minor,
+			Patch: patch + 1,
 		}
 		err = CreateReleaseVersion(version)
 		if nil != err {

--- a/internal/service/version_triage_info.go
+++ b/internal/service/version_triage_info.go
@@ -34,7 +34,6 @@ func CreateOrUpdateVersionTriageInfo(versionTriage *entity.VersionTriage) (*dto.
 
 	// create or update
 	var isFrozen bool = releaseVersion.Status == entity.ReleaseVersionStatusFrozen
-	var isRelease bool = releaseVersion.Status == entity.ReleaseVersionStatusReleased
 	var isAccept bool = versionTriage.TriageResult == entity.VersionTriageResultAccept
 	if isFrozen && isAccept {
 		versionTriage.TriageResult = entity.VersionTriageResultAcceptFrozen
@@ -60,8 +59,7 @@ func CreateOrUpdateVersionTriageInfo(versionTriage *entity.VersionTriage) (*dto.
 				if err != nil {
 					return nil, err
 				}
-			}
-			if !isAccept && !isRelease {
+			} else {
 				err := RemoveLabelByPullRequestID(pr.PullRequestID, git.CherryPickLabel)
 				if err != nil {
 					return nil, err
@@ -183,7 +181,7 @@ func FindReleaseVersion(versionTriage *entity.VersionTriage) (*entity.ReleaseVer
 	if shortType == entity.ReleaseVersionShortTypeMinor {
 		option.Major = major
 		option.Minor = minor
-		option.Status = entity.ReleaseVersionStatusUpcoming
+		option.StatusList = []entity.ReleaseVersionStatus{entity.ReleaseVersionStatusUpcoming, entity.ReleaseVersionStatusFrozen}
 	} else if shortType == entity.ReleaseVersionShortTypePatch || shortType == entity.ReleaseVersionShortTypeHotfix {
 		option.Major = major
 		option.Minor = minor
@@ -200,9 +198,9 @@ func FindReleaseVersion(versionTriage *entity.VersionTriage) (*entity.ReleaseVer
 	if err != nil {
 		return nil, err
 	}
-	if releaseVersion.Status != entity.ReleaseVersionStatusUpcoming {
-		return nil, errors.Wrap(err, fmt.Sprintf("find lastest version is not upcoming: %+v failed", releaseVersion))
-	}
+	// if releaseVersion.Status != entity.ReleaseVersionStatusUpcoming {
+	// 	return nil, errors.Wrap(err, fmt.Sprintf("find lastest version is not upcoming: %+v failed", releaseVersion))
+	// }
 	return releaseVersion, nil
 }
 

--- a/internal/service/version_triage_info.go
+++ b/internal/service/version_triage_info.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"fmt"
 	"strings"
 
 	"tirelease/commons/git"
@@ -14,7 +13,7 @@ import (
 
 func CreateOrUpdateVersionTriageInfo(versionTriage *entity.VersionTriage) (*dto.VersionTriageInfo, error) {
 	// find version
-	releaseVersion, err := FindReleaseVersion(versionTriage)
+	releaseVersion, err := SelectReleaseVersionActive(versionTriage.VersionName)
 	if err != nil {
 		return nil, err
 	}
@@ -171,37 +170,6 @@ func InheritVersionTriage(fromVersion string, toVersion string) error {
 	}
 
 	return nil
-}
-
-func FindReleaseVersion(versionTriage *entity.VersionTriage) (*entity.ReleaseVersion, error) {
-	// release_version option
-	shortType := ComposeVersionShortType(versionTriage.VersionName)
-	major, minor, patch, _ := ComposeVersionAtom(versionTriage.VersionName)
-	option := &entity.ReleaseVersionOption{}
-	if shortType == entity.ReleaseVersionShortTypeMinor {
-		option.Major = major
-		option.Minor = minor
-		option.StatusList = []entity.ReleaseVersionStatus{entity.ReleaseVersionStatusUpcoming, entity.ReleaseVersionStatusFrozen}
-	} else if shortType == entity.ReleaseVersionShortTypePatch || shortType == entity.ReleaseVersionShortTypeHotfix {
-		option.Major = major
-		option.Minor = minor
-		option.Patch = patch
-	} else {
-		return nil, errors.New(fmt.Sprintf("CreateOrUpdateVersionTriageInfo params invalid: %+v failed", versionTriage))
-	}
-
-	// find version
-	if option == nil {
-		return nil, errors.New(fmt.Sprintf("CheckReleaseVersion params invalid: %+v failed", option))
-	}
-	releaseVersion, err := repository.SelectReleaseVersionLatest(option)
-	if err != nil {
-		return nil, err
-	}
-	// if releaseVersion.Status != entity.ReleaseVersionStatusUpcoming {
-	// 	return nil, errors.Wrap(err, fmt.Sprintf("find lastest version is not upcoming: %+v failed", releaseVersion))
-	// }
-	return releaseVersion, nil
 }
 
 func ComposeVersionTriageMergeStatus(issueRelationInfo *dto.IssueRelationInfo) entity.VersionTriageMergeStatus {

--- a/internal/service/version_triage_info_test.go
+++ b/internal/service/version_triage_info_test.go
@@ -34,8 +34,9 @@ func TestSelectVersionTriageInfo(t *testing.T) {
 
 	query := &dto.VersionTriageInfoQuery{
 		VersionTriageOption: entity.VersionTriageOption{
-			VersionName: "5.1.1",
+			VersionName: "5.2.2",
 		},
+		Version: "5.2.2",
 	}
 	info, response, err := SelectVersionTriageInfo(query)
 	assert.Equal(t, true, err == nil)

--- a/website/src/components/issues/GridColumns.js
+++ b/website/src/components/issues/GridColumns.js
@@ -21,6 +21,7 @@ const repo = {
 const number = {
   field: "number",
   headerName: "Number",
+  type: 'number',
   valueGetter: (params) => params.row.issue.number,
   renderCell: (params) => (
     <a

--- a/website/src/components/issues/GridColumns.js
+++ b/website/src/components/issues/GridColumns.js
@@ -172,7 +172,7 @@ const Columns = {
   getAffectionOnVersion,
   getPROnVersion,
   getPickOnVersion,
-  issueBasicInfo: [id, repo, number, title],
+  issueBasicInfo: [id, repo, number, title, severity],
 };
 
 export default Columns;

--- a/website/src/components/issues/renderer/Affection.js
+++ b/website/src/components/issues/renderer/Affection.js
@@ -16,9 +16,6 @@ export function getAffection(version) {
 export function renderAffection(version) {
   return (params) => {
     const affection = getAffection(version)(params);
-    if (affection === "N/A") {
-      return <>N/A</>;
-    }
     return (
       <AffectionSelect
         id={params.row.issue.issue_id}

--- a/website/src/components/issues/renderer/AffectionSelect.js
+++ b/website/src/components/issues/renderer/AffectionSelect.js
@@ -45,9 +45,8 @@ export default function AffectionSelect({
               onChange={handleChange}
               label="Affection"
             >
-              <MenuItem value="unknown">
-                <em>unknown</em>
-              </MenuItem>
+              <MenuItem value={"N/A"} disabled={true}>-</MenuItem>
+              <MenuItem value={"unknown"}>unknown</MenuItem>
               <MenuItem value={"no"}>no</MenuItem>
               <MenuItem value={"yes"}>yes</MenuItem>
             </Select>

--- a/website/src/components/issues/renderer/PickSelect.js
+++ b/website/src/components/issues/renderer/PickSelect.js
@@ -50,9 +50,8 @@ export default function PickSelect({
               label="Affection"
               disabled={pick.startsWith("released")}
             >
-              <MenuItem value="unknown">
-                <em>unknown</em>
-              </MenuItem>
+              <MenuItem value="N/A" disabled={true}>-</MenuItem>
+              <MenuItem value="unknown">unknown</MenuItem>
               <MenuItem value={"accept"}>
                 <div style={{ color: "green", fontWeight: "bold" }}>
                   approved
@@ -60,7 +59,7 @@ export default function PickSelect({
               </MenuItem>
               <MenuItem value={"later"}>later</MenuItem>
               <MenuItem value={"won't fix"}>won't fix</MenuItem>
-              <MenuItem value={"accept(frozen)"}>approved (frozen)</MenuItem>
+              <MenuItem value={"accept(frozen)"} disabled={true}>approved (frozen)</MenuItem>
               <MenuItem value={"released"} disabled={true}>
                 released in {patch}
               </MenuItem>

--- a/website/src/components/issues/renderer/PickSelect.js
+++ b/website/src/components/issues/renderer/PickSelect.js
@@ -50,8 +50,8 @@ export default function PickSelect({
               label="Affection"
               disabled={pick.startsWith("released")}
             >
-              <MenuItem value="N/A" disabled={true}>-</MenuItem>
-              <MenuItem value="unknown">unknown</MenuItem>
+              <MenuItem value={"N/A"} disabled={true}>-</MenuItem>
+              <MenuItem value={"unknown"}>unknown</MenuItem>
               <MenuItem value={"accept"}>
                 <div style={{ color: "green", fontWeight: "bold" }}>
                   approved

--- a/website/src/components/issues/renderer/PickTriage.js
+++ b/website/src/components/issues/renderer/PickTriage.js
@@ -1,46 +1,42 @@
 import PickSelect from "./PickSelect";
-import Button from "@mui/material/Button";
 import { getAffection } from "./Affection";
 
 export function getPickTriageValue(version) {
   return (params) => {
     const affection = getAffection(version)(params);
     if (affection === "N/A" || affection === "no") {
-      return "N/A";
+      return <>not affect</>;
     }
-    const pick = params.row.version_triages?.filter((t) =>
+    const version_triage = params.row.version_triages?.filter((t) =>
       t.version_name.startsWith(version)
     )[0];
-    if (pick === undefined) {
-      return "unknown";
+    if (version_triage === undefined) {
+      return "N/A"
     }
-    return pick.triage_result?.toLocaleLowerCase();
+    return version_triage.triage_result?.toLocaleLowerCase();
   };
 }
 
 export function renderPickTriage(version) {
   return (params) => {
+    
     const affection = getAffection(version)(params);
     if (affection === "N/A" || affection === "no") {
       return <>not affect</>;
     }
-    let pick = params.row.version_triages?.filter((t) =>
+    let version_triage = params.row.version_triages?.filter((t) =>
       t.version_name.startsWith(version)
     )[0];
-    if (pick === undefined && params.row.version_triage !== undefined) {
-      pick = params.row.version_triage;
-    }
-    console.log(pick);
-    const value =
-      pick === undefined ? "unknown" : pick.triage_result?.toLocaleLowerCase();
-    const patch = pick === undefined ? "unknown" : pick.version_name;
+    const pick = version_triage === undefined ? "N/A" : version_triage.triage_result?.toLocaleLowerCase();
+    const patch = version_triage === undefined ? "N/A" : version_triage.version_name;
+
     return (
       <>
         <PickSelect
           id={params.row.issue.issue_id}
           version={version}
           patch={patch}
-          pick={value}
+          pick={pick}
         ></PickSelect>
       </>
     );

--- a/website/src/components/release/ReleaseTable.js
+++ b/website/src/components/release/ReleaseTable.js
@@ -109,7 +109,7 @@ const ReleaseTable = () => {
               navigate(`/home/triage/${v}`, { replace: true });
             }}
           />
-          <Button
+          {/* <Button
             variant="outlined"
             onClick={handleClickOpen}
             disabled={version === "none"}
@@ -132,13 +132,13 @@ const ReleaseTable = () => {
                 this release are triaged and settled.
               </DialogContentText>
             </DialogContent>
-            {/* <DialogActions>
+            <DialogActions>
               <Button onClick={handleClose}>Cancel</Button>
               <Button onClick={handleClose} autoFocus>
                 Release
               </Button>
-            </DialogActions> */}
-          </Dialog>
+            </DialogActions>
+          </Dialog> */}
         </Stack>
         {version !== "none" && (
           <ReleaseCandidates version={version}></ReleaseCandidates>

--- a/website/src/components/release/VersionSelector.js
+++ b/website/src/components/release/VersionSelector.js
@@ -2,6 +2,7 @@ import * as React from "react";
 import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
+import InputLabel from '@mui/material/InputLabel';
 import { useQuery } from "react-query";
 import { url } from "../../utils";
 
@@ -31,12 +32,16 @@ const VersionSelector = ({ versionProp, onChange }) => {
 
   return (
     <>
-      <FormControl variant="standard" sx={{ m: 0, minWidth: 120 }}>
+      <FormControl variant="standard" sx={{ m: 0, minWidth: 240 }}>
+        <InputLabel>
+          Version
+        </InputLabel>
         <Select
           value={version}
           onChange={handleChange}
-          displayEsmpty
-          inputProps={{ "aria-label": "Without label" }}
+          // displayEsmpty
+          // inputProps={{ "aria-label": "Without label" }}
+          label="Version"
         >
           <MenuItem value="none">
             <em>none</em>


### PR DESCRIPTION
1.页面重构为四大部分: 版本管理、triage管理、issue数据中心
2.N/A优化，页面N/A允许用户下拉编辑
3.版本逻辑封装，版本发布自动创建下一版本能力测试
4.版本cherry-pick triage逻辑调整：版本vertion triage = 版本全量affect - 历史版本released
5.vertion_triage页面新增severity、by numer的过滤条件优化
6.issue中心列表性能优化，变更多次查询为单次批量查询
7.repository层均支持sql组装，支持多样化查询